### PR TITLE
handle deep inserted nodes while visiting with 'enter' correctly

### DIFF
--- a/alias/language/visitor.mjs
+++ b/alias/language/visitor.mjs
@@ -72,7 +72,7 @@ export function visit(node, visitor) {
     if (resultLeave !== undefined) {
       return resultLeave;
     } else if (resultEnter !== undefined) {
-      return resultEnter;
+      return hasEdited ? copy : resultEnter;
     } else {
       return hasEdited ? copy : node;
     }


### PR DESCRIPTION
Fixes https://github.com/kitten/graphql-web-lite/issues/6